### PR TITLE
Update firmware_uploader.c - don't use this, use next pull request for "firmware_updater"

### DIFF
--- a/script/tools/firmware_uploader.c
+++ b/script/tools/firmware_uploader.c
@@ -188,9 +188,9 @@ int main(int argc, char *argv[]) {
         total += bytes_read;
 
         // Show progress
-        printf("\n📊 Progress: %s / %s", 
-              bytes_to_human(total), 
-              bytes_to_human(file_size));
+        char totalBytes = bytes_to_human(total);        // we have to store the result inbetween the successive calls since the static local variable as return value overwrites total by file_size,
+        char fsizeBytes = bytes_to_human(file_size);    //      both values are always shown as equal values, no progress information. deHarro
+        printf("\n📊 Progress: %s / %s", totalBytes, fsizeBytes);
 
         // Wait for device ready
         int retry = 0;


### PR DESCRIPTION
Passing a static local variable as returnvalue of a subroutine may cause issues (as seen here). Changed code to straighten out the problem. Actual, there was no visible progress since both values displayed were equal all the time.