### PR TITLE
Update battery_monitor.py

### DIFF
--- a/script/tools/python_demo/battery_monitor.py
+++ b/script/tools/python_demo/battery_monitor.py
@@ -58,7 +58,7 @@ def check_battery_status():
     battery_voltage, battery_current = read_battery_status()
     logging.info(f"Battery Voltage: {battery_voltage}mV, Current: {battery_current}mA.")
     
-    if battery_voltage < BATTERY_VOLTAGE_THRESHOLD:
+    if battery_voltage < BATTERY_VOLTAGE_THRESHOLD * 2:    # check for double the defined threshold, we have two batteries in series!, deHarro
         logging.info(f"Battery voltage is below {BATTERY_VOLTAGE_THRESHOLD}mV. Initiating shutdown.")
         logging.info(f"Battery voltage is below {BATTERY_VOLTAGE_THRESHOLD}mV. Initiating shutdown.")
         subprocess.run(SHUTDOWN_COMMAND, shell=True)


### PR DESCRIPTION
For shutting down the Raspberry Pi we need to check for 7400 mV since we have 2 batteries in series configuration. The define says 3700 mV.