### PR TITLE
Update read_device.c

### DIFF
--- a/script/tools/read_device.c
+++ b/script/tools/read_device.c
@@ -130,7 +130,7 @@ void debug_print(DeviceStatus* status) {
     printf("Power-on auto-start battery voltage threshold : %u mV\n", status->auto_start_voltage);
     printf("Reserved Register :    0x%04X\n", status->rsv);
     printf("Request OTA(Over-The-Air update) :   0x%04X\n", status->ota_request);
-    printf("Accumulated operating time :  %llu microseconds\n", status->runtime);
+    printf("Accumulated operating time :  %lu milliseconds\n", status->runtime);
     printf("Charging chip trigger interval :     %u seconds\n", status->charge_detect_interval_s);
     printf("LED Control:               0x%02X\n", status->led_ctl);
 


### PR DESCRIPTION
I proposed to introduce major/minor version info for the firmware of the UPSv6. The major version should then be declared in the upper 3 bit of the version register, the minor version resides in the lower 5 bit. This schema allows for versions up to V7.31, obviously enough for the next decade of the UPS :) In anticipation of that extension I changed the display of "version" to accomplish the old and the expected implementation of firmware version info.